### PR TITLE
add pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+      - id: fmt
+        args: ['--verbose', '--']
+      - id: clippy
+        args: ['--', '-D', 'warnings']

--- a/README.md
+++ b/README.md
@@ -69,6 +69,22 @@ ibtop
 
 Apache License 2.0
 
+## Development
+
+### Pre-commit Hooks
+
+This project uses pre-commit hooks to ensure code quality. To set them up:
+
+```bash
+# Install pre-commit
+pip install pre-commit
+
+# Install the git hook scripts
+pre-commit install
+```
+
+The hooks will automatically run `cargo fmt` and `cargo clippy` before each commit.
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.


### PR DESCRIPTION
# Adding pre-commit hook for formatting


I noticed on my previous pr that my code was not formatted correctly and ci did not pass. I am adding this pre-commit hook so that it is automatic

example of how it looks like
<img width="1028" height="170" alt="Screenshot from 2025-08-27 10-11-12" src="https://github.com/user-attachments/assets/915c688b-4a54-4530-8b4c-c73c857f4666" />
