### PR TITLE
Add bits/sec throughput display option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,19 @@ sudo cp target/release/ibtop /usr/local/bin/
 ```bash
 # Monitor all InfiniBand adapters
 ibtop
+
+# Start with throughput shown in bits/sec
+ibtop --bits
 ```
 
 ### Controls
 
 - `q` or `ESC` - Quit
+- `j` / `k` or arrow keys - Navigate ports
+- `Enter` - Toggle detail view
+- `b` - Toggle bits/sec vs bytes/sec throughput
+- `Tab` / `Shift+Tab` - Switch detail tabs (when detail view is open)
+- `r` - Force refresh
 
 ## Requirements
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,11 +28,12 @@ fn get_hostname() -> String {
 fn main() -> Result<(), io::Error> {
     let args: Vec<String> = env::args().collect();
     let json_mode = args.contains(&String::from("--json"));
+    let use_bits = args.contains(&String::from("--bits"));
 
     if json_mode {
         run_json_mode()
     } else {
-        run_interactive_mode()
+        run_interactive_mode(use_bits)
     }
 }
 
@@ -60,14 +61,14 @@ fn run_json_mode() -> Result<(), io::Error> {
     Ok(())
 }
 
-fn run_interactive_mode() -> Result<(), io::Error> {
+fn run_interactive_mode(use_bits: bool) -> Result<(), io::Error> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let res = run_app(&mut terminal);
+    let res = run_app(&mut terminal, use_bits);
 
     disable_raw_mode()?;
     execute!(
@@ -84,10 +85,14 @@ fn run_interactive_mode() -> Result<(), io::Error> {
     Ok(())
 }
 
-fn run_app<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>) -> io::Result<()> {
+fn run_app<B: ratatui::backend::Backend>(
+    terminal: &mut Terminal<B>,
+    use_bits: bool,
+) -> io::Result<()> {
     let use_fake_data = std::env::var("IBTOP_FAKE_DATA").is_ok();
     let mut metrics = metrics::MetricsCollector::new();
     let mut app_state = ui::AppState::new();
+    app_state.use_bits = use_bits;
     let hostname = get_hostname();
 
     let ui_refresh_duration = Duration::from_millis(UI_REFRESH_INTERVAL_MS);
@@ -131,10 +136,11 @@ fn run_app<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>) -> io::Resu
                     KeyCode::Char('j') | KeyCode::Down => app_state.select_next(),
                     KeyCode::Char('k') | KeyCode::Up => app_state.select_prev(),
 
-                    // Detail view
+                    // Detail view and display units
                     KeyCode::Enter => app_state.toggle_detail(),
                     KeyCode::Tab if app_state.detail_expanded => app_state.next_tab(),
                     KeyCode::BackTab if app_state.detail_expanded => app_state.prev_tab(),
+                    KeyCode::Char('b') => app_state.toggle_bits(),
 
                     // Force refresh
                     KeyCode::Char('r') => {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -41,6 +41,8 @@ pub struct AppState {
     pub scroll_offset: usize,
     /// Animation frame counter
     pub frame_count: u64,
+    /// Display throughput in bits/sec instead of bytes/sec
+    pub use_bits: bool,
     /// List of selectable items (adapter, port) or None for adapter headers
     selectable_items: Vec<Option<(String, u16)>>,
 }
@@ -85,6 +87,11 @@ impl AppState {
     /// Toggle detail view
     pub fn toggle_detail(&mut self) {
         self.detail_expanded = !self.detail_expanded;
+    }
+
+    /// Toggle bits/sec vs bytes/sec throughput display
+    pub fn toggle_bits(&mut self) {
+        self.use_bits = !self.use_bits;
     }
 
     /// Get currently selected port
@@ -263,8 +270,8 @@ fn draw_main_table(
                 // Get throughput values
                 let (rx_rate, tx_rate) = if let Some(m) = port_metrics {
                     (
-                        format_bytes_per_sec(m.rx_bytes_per_sec),
-                        format_bytes_per_sec(m.tx_bytes_per_sec),
+                        format_throughput(m.rx_bytes_per_sec, state.use_bits),
+                        format_throughput(m.tx_bytes_per_sec, state.use_bits),
                     )
                 } else {
                     ("--".to_string(), "--".to_string())
@@ -368,12 +375,12 @@ fn draw_main_table(
                     Span::styled("  │  ", Style::default().fg(Color::DarkGray)),
                     Span::styled("▲ ", Style::default().fg(Color::Green)),
                     Span::styled(
-                        format_bytes_per_sec(total_rx),
+                        format_throughput(total_rx, state.use_bits),
                         Style::default().fg(Color::Green),
                     ),
                     Span::styled("  ▼ ", Style::default().fg(Color::Blue)),
                     Span::styled(
-                        format_bytes_per_sec(total_tx),
+                        format_throughput(total_tx, state.use_bits),
                         Style::default().fg(Color::Blue),
                     ),
                     Span::styled(" ", Style::default()),
@@ -384,6 +391,7 @@ fn draw_main_table(
     frame.render_widget(table, chunks[0]);
 
     // Help footer - context-sensitive
+    let bits_help = if state.use_bits { " bytes" } else { " bits" };
     let help_spans = if state.detail_expanded {
         vec![
             Span::styled(" ", Style::default().fg(Color::DarkGray)),
@@ -393,6 +401,9 @@ fn draw_main_table(
             Span::styled(" close  ", Style::default().fg(Color::DarkGray)),
             Span::styled("j/k", Style::default().fg(Color::Cyan)),
             Span::styled(" select port  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("b", Style::default().fg(Color::Cyan)),
+            Span::styled(bits_help, Style::default().fg(Color::DarkGray)),
+            Span::styled("  ", Style::default().fg(Color::DarkGray)),
             Span::styled("q", Style::default().fg(Color::Cyan)),
             Span::styled(" quit ", Style::default().fg(Color::DarkGray)),
         ]
@@ -403,6 +414,9 @@ fn draw_main_table(
             Span::styled(" navigate  ", Style::default().fg(Color::DarkGray)),
             Span::styled("Enter", Style::default().fg(Color::Cyan)),
             Span::styled(" details  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("b", Style::default().fg(Color::Cyan)),
+            Span::styled(bits_help, Style::default().fg(Color::DarkGray)),
+            Span::styled("  ", Style::default().fg(Color::DarkGray)),
             Span::styled("q", Style::default().fg(Color::Cyan)),
             Span::styled(" quit ", Style::default().fg(Color::DarkGray)),
         ]
@@ -497,12 +511,12 @@ fn draw_detail_panel(
             Span::styled("| ", Style::default().fg(Color::DarkGray)),
             Span::styled("RX: ", Style::default().fg(Color::DarkGray)),
             Span::styled(
-                format_bytes_per_sec(m.rx_bytes_per_sec),
+                format_throughput(m.rx_bytes_per_sec, state.use_bits),
                 Style::default().fg(Color::Blue),
             ),
             Span::styled(" TX: ", Style::default().fg(Color::DarkGray)),
             Span::styled(
-                format_bytes_per_sec(m.tx_bytes_per_sec),
+                format_throughput(m.tx_bytes_per_sec, state.use_bits),
                 Style::default().fg(Color::Magenta),
             ),
         ]);
@@ -513,35 +527,56 @@ fn draw_detail_panel(
 
     // Chart area
     if let Some(h) = history {
-        draw_chart(frame, detail_layout[2], h, state.detail_tab);
+        draw_chart(frame, detail_layout[2], h, state.detail_tab, state.use_bits);
     } else {
         let msg = Paragraph::new("Collecting data...").style(Style::default().fg(Color::DarkGray));
         frame.render_widget(msg, detail_layout[2]);
     }
 }
 
-/// Auto-scale throughput value and return scaled value with unit
-fn auto_scale_throughput(bytes_per_sec: f64) -> (f64, &'static str) {
-    if bytes_per_sec >= 1_000_000_000.0 {
-        (bytes_per_sec / 1_000_000_000.0, "GB/s")
-    } else if bytes_per_sec >= 1_000_000.0 {
-        (bytes_per_sec / 1_000_000.0, "MB/s")
-    } else if bytes_per_sec >= 1_000.0 {
-        (bytes_per_sec / 1_000.0, "KB/s")
+/// Auto-scale throughput value and return scaled value with unit.
+/// `rate` is bytes/sec when `use_bits` is false, or bits/sec when true.
+fn auto_scale_throughput(rate: f64, use_bits: bool) -> (f64, &'static str) {
+    if use_bits {
+        if rate >= 1_000_000_000_000.0 {
+            (rate / 1_000_000_000_000.0, "Tb/s")
+        } else if rate >= 1_000_000_000.0 {
+            (rate / 1_000_000_000.0, "Gb/s")
+        } else if rate >= 1_000_000.0 {
+            (rate / 1_000_000.0, "Mb/s")
+        } else if rate >= 1_000.0 {
+            (rate / 1_000.0, "Kb/s")
+        } else {
+            (rate, "b/s")
+        }
+    } else if rate >= 1_000_000_000.0 {
+        (rate / 1_000_000_000.0, "GB/s")
+    } else if rate >= 1_000_000.0 {
+        (rate / 1_000_000.0, "MB/s")
+    } else if rate >= 1_000.0 {
+        (rate / 1_000.0, "KB/s")
     } else {
-        (bytes_per_sec, "B/s")
+        (rate, "B/s")
     }
 }
 
 /// Draw a chart based on the selected tab
 #[allow(clippy::too_many_lines)]
-fn draw_chart(frame: &mut Frame, area: Rect, history: &PortHistory, tab: usize) {
+fn draw_chart(frame: &mut Frame, area: Rect, history: &PortHistory, tab: usize, use_bits: bool) {
     // First, find the max value to determine scale
     let (rx_raw, tx_raw): (Vec<f64>, Vec<f64>) = match tab {
-        0 => (
-            history.rx_bytes_per_sec.iter().copied().collect(),
-            history.tx_bytes_per_sec.iter().copied().collect(),
-        ),
+        0 => {
+            let rx: Vec<f64> = history.rx_bytes_per_sec.iter().copied().collect();
+            let tx: Vec<f64> = history.tx_bytes_per_sec.iter().copied().collect();
+            if use_bits {
+                (
+                    rx.into_iter().map(|v| v * 8.0).collect(),
+                    tx.into_iter().map(|v| v * 8.0).collect(),
+                )
+            } else {
+                (rx, tx)
+            }
+        }
         1 => (
             history.rx_packets_per_sec.iter().copied().collect(),
             history.tx_packets_per_sec.iter().copied().collect(),
@@ -566,12 +601,13 @@ fn draw_chart(frame: &mut Frame, area: Rect, history: &PortHistory, tab: usize) 
     // Determine scale and unit based on max value
     let (divisor, y_label) = match tab {
         0 => {
-            // Throughput - auto-scale
-            let (_, unit) = auto_scale_throughput(max_raw);
+            // Throughput - auto-scale (bytes or bits depending on mode)
+            let (_, unit) = auto_scale_throughput(max_raw, use_bits);
             let div = match unit {
-                "GB/s" => 1_000_000_000.0,
-                "MB/s" => 1_000_000.0,
-                "KB/s" => 1_000.0,
+                "TB/s" | "Tb/s" => 1_000_000_000_000.0,
+                "GB/s" | "Gb/s" => 1_000_000_000.0,
+                "MB/s" | "Mb/s" => 1_000_000.0,
+                "KB/s" | "Kb/s" => 1_000.0,
                 _ => 1.0,
             };
             (div, unit)
@@ -755,6 +791,33 @@ pub fn format_bytes_per_sec(bytes_per_sec: f64) -> String {
     }
 }
 
+/// Format a bit-rate using SI decimal units (network convention).
+pub fn format_bits_per_sec(bits_per_sec: f64) -> String {
+    const UNITS: &[&str] = &["b/s", "Kb/s", "Mb/s", "Gb/s", "Tb/s"];
+    let mut value = bits_per_sec;
+    let mut unit_index = 0;
+
+    while value >= 1000.0 && unit_index < UNITS.len() - 1 {
+        value /= 1000.0;
+        unit_index += 1;
+    }
+
+    if value < 0.1 {
+        format!("{:.2}{}", value, UNITS[unit_index])
+    } else {
+        format!("{:.1}{}", value, UNITS[unit_index])
+    }
+}
+
+/// Format throughput as bytes/sec or bits/sec depending on `use_bits`.
+pub fn format_throughput(bytes_per_sec: f64, use_bits: bool) -> String {
+    if use_bits {
+        format_bits_per_sec(bytes_per_sec * 8.0)
+    } else {
+        format_bytes_per_sec(bytes_per_sec)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -783,6 +846,34 @@ mod tests {
             format_bytes_per_sec(1024.0 * 1024.0 * 1024.0 * 1024.0),
             "1.0TB/s"
         );
+    }
+
+    #[test]
+    fn test_format_bits_per_sec() {
+        assert_eq!(format_bits_per_sec(0.0), "0.00b/s");
+        assert_eq!(format_bits_per_sec(999.0), "999.0b/s");
+        assert_eq!(format_bits_per_sec(1000.0), "1.0Kb/s");
+        assert_eq!(format_bits_per_sec(1_000_000.0), "1.0Mb/s");
+        assert_eq!(format_bits_per_sec(1_000_000_000.0), "1.0Gb/s");
+        assert_eq!(format_bits_per_sec(100_000_000_000.0), "100.0Gb/s");
+        assert_eq!(format_bits_per_sec(1_000_000_000_000.0), "1.0Tb/s");
+    }
+
+    #[test]
+    fn test_format_throughput_bits_mode() {
+        // 12.5 GB/s bytes == 100 Gb/s bits
+        assert_eq!(format_throughput(12_500_000_000.0, true), "100.0Gb/s");
+        assert_eq!(format_throughput(12_500_000_000.0, false), "11.6GB/s");
+    }
+
+    #[test]
+    fn test_toggle_bits() {
+        let mut state = AppState::new();
+        assert!(!state.use_bits);
+        state.toggle_bits();
+        assert!(state.use_bits);
+        state.toggle_bits();
+        assert!(!state.use_bits);
     }
 
     #[test]


### PR DESCRIPTION
Support --bits and the b key to toggle throughput between bytes/sec and bits/sec across the table, totals, detail view, and charts.

example:
```
ibtop --bits
```
<img width="1703" height="429" alt="image" src="https://github.com/user-attachments/assets/596a3dbb-0f22-4ec0-b472-57f117b8708a" />
